### PR TITLE
Add raw template support

### DIFF
--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -266,7 +266,7 @@ class Action(BaseAction):
         template = self._template(stack.blueprint)
         tags = build_stack_tags(stack)
         parameters = self.build_parameters(stack, provider_stack)
-        force_change_set = stack.blueprint.template.transform is not None
+        force_change_set = stack.blueprint.requires_change_set
 
         if recreate:
             logger.debug("Re-creating stack: %s", stack.fqn)

--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -523,6 +523,11 @@ class Blueprint(object):
         self.template.add_description(description)
 
     @property
+    def requires_change_set(self):
+        """Returns true if the underlying template has transforms."""
+        return self.template.transform is not None
+
+    @property
     def rendered(self):
         if not self._rendered:
             self._version, self._rendered = self.render_template()

--- a/stacker/tests/blueprints/test_raw.py
+++ b/stacker/tests/blueprints/test_raw.py
@@ -60,7 +60,16 @@ class TestBlueprintRendering(unittest.TestCase):
                         "Type": "CommaDelimitedList"
                     }
                 },
-                "Resources": {}
+                "Resources": {
+                    "Dummy": {
+                        "Type": "AWS::CloudFormation::WaitConditionHandle"
+                    }
+                },
+                "Outputs": {
+                    "DummyId": {
+                        "Value": "dummy-1234"
+                    }
+                }
             },
             sort_keys=True,
             indent=4

--- a/stacker/tests/fixtures/cfn_template.json
+++ b/stacker/tests/fixtures/cfn_template.json
@@ -10,5 +10,14 @@
             "Type": "CommaDelimitedList"
         }
     },
-    "Resources": {}
+    "Resources": {
+      "Dummy": {
+        "Type": "AWS::CloudFormation::WaitConditionHandle"
+      }
+    },
+    "Outputs": {
+      "DummyId": {
+        "Value": "dummy-1234"
+      }
+    }
 }

--- a/stacker/tests/fixtures/cfn_template.yaml
+++ b/stacker/tests/fixtures/cfn_template.yaml
@@ -6,4 +6,9 @@ Parameters:
   Param2:
     Default: default
     Type: CommaDelimitedList
-Resources: {}
+Resources:
+  Dummy:
+    Type: AWS::CloudFormation::WaitConditionHandle
+Outputs:
+  DummyId:
+    Value: dummy-1234

--- a/stacker/tests/test_config.py
+++ b/stacker/tests/test_config.py
@@ -51,8 +51,17 @@ class TestConfig(unittest.TestCase):
             "stacks": [
                 {
                     "name": "bastion"}]})
-        with self.assertRaises(exceptions.InvalidConfig):
+        with self.assertRaises(exceptions.InvalidConfig) as ex:
             config.validate()
+
+        stack_errors = ex.exception.errors['stacks'][0]
+        print stack_errors
+        self.assertEquals(
+            stack_errors['template_path'][0].__str__(),
+            "class_path or template_path is required.")
+        self.assertEquals(
+            stack_errors['class_path'][0].__str__(),
+            "class_path or template_path is required.")
 
     def test_config_validate_stack_class_and_template_paths(self):
         config = Config({
@@ -62,8 +71,16 @@ class TestConfig(unittest.TestCase):
                     "name": "bastion",
                     "class_path": "foo",
                     "template_path": "bar"}]})
-        with self.assertRaises(exceptions.InvalidConfig):
+        with self.assertRaises(exceptions.InvalidConfig) as ex:
             config.validate()
+
+        stack_errors = ex.exception.errors['stacks'][0]
+        self.assertEquals(
+            stack_errors['template_path'][0].__str__(),
+            "class_path cannot be present when template_path is provided.")
+        self.assertEquals(
+            stack_errors['class_path'][0].__str__(),
+            "template_path cannot be present when class_path is provided.")
 
     def test_config_validate_no_stacks(self):
         config = Config({"namespace": "prod"})

--- a/tests/suite.bats
+++ b/tests/suite.bats
@@ -684,3 +684,44 @@ EOF
   assert_has_line "${STACKER_NAMESPACE}-dependent-rollback-parent: failed (rolled back new stack)"
   assert_has_line "${STACKER_NAMESPACE}-dependent-rollback-child:  failed (dependency has failed)"
 }
+
+@test "stacker build - raw template" {
+  needs_aws
+
+  config() {
+    cat <<EOF
+namespace: ${STACKER_NAMESPACE}
+stacks:
+  - name: vpc
+    template_path: ../stacker/tests/fixtures/cfn_template.json
+    variables:
+      Param1: foobar
+EOF
+  }
+
+  teardown() {
+    stacker destroy --force <(config)
+  }
+
+  # Create the new stacks.
+  stacker build <(config)
+  assert "$status" -eq 0
+  assert_has_line "Using default AWS provider mode"
+  assert_has_line "${STACKER_NAMESPACE}-vpc: pending"
+  assert_has_line "${STACKER_NAMESPACE}-vpc: submitted (creating new stack)"
+  assert_has_line "${STACKER_NAMESPACE}-vpc: complete (creating new stack)"
+
+  # Perform a noop update to the stacks, in interactive mode.
+  stacker build -i <(config)
+  assert "$status" -eq 0
+  assert_has_line "Using interactive AWS provider mode"
+  assert_has_line "${STACKER_NAMESPACE}-vpc: pending"
+  assert_has_line "${STACKER_NAMESPACE}-vpc: skipped (nochange)"
+
+  # Cleanup
+  stacker destroy --force <(config)
+  assert "$status" -eq 0
+  assert_has_line "${STACKER_NAMESPACE}-vpc: pending"
+  assert_has_line "${STACKER_NAMESPACE}-vpc: submitted (submitted for destruction)"
+  assert_has_line "${STACKER_NAMESPACE}-vpc: complete (stack destroyed)"
+}


### PR DESCRIPTION
This is a few small changes to https://github.com/remind101/stacker/pull/530.

1. Adds a commit to handle the mutual exclusion validation between class_path/template_path ready.
2. Makes RawTemplateBlueprint inherit from object. Basically nothing was being re-used, so this'll make it easier to maintain, and ensure that we have a simple interface from actions -> blueprints.
3. Adds a happy path functional test to make sure we don't break this moving forward.